### PR TITLE
prevent event from bubbling up.

### DIFF
--- a/dist/jquery.animatecss.js
+++ b/dist/jquery.animatecss.js
@@ -67,7 +67,8 @@
         }
       };
       complete = function(element) {
-        return element.one(transitionEnd, function() {
+        return element.one(transitionEnd, function(event) {
+          event.stopPropagation();
           return callback(element);
         });
       };


### PR DESCRIPTION
cancel event bubbling up to avoid nested element fire event two times.